### PR TITLE
fix(notifications): parse the bulk upload CSV by records, not by newlines

### DIFF
--- a/src/context/notifications/notifications.service.ts
+++ b/src/context/notifications/notifications.service.ts
@@ -10,6 +10,8 @@ import { ConfigService } from "@nestjs/config";
 import axios from "axios";
 import FormData from "form-data";
 
+import { parseCsvRecords } from "@/src/context/shared/utils/csv.utils";
+
 import { BulkStatusResponseDto } from "./dto/bulk-status.dto";
 import { BulkUploadResponseDto } from "./dto/bulk-upload.dto";
 import { CreateNotificationDto } from "./dto/create-notification.dto";
@@ -37,44 +39,38 @@ export class NotificationsService {
     ) {}
 
     private parseCSV(buffer: Buffer): CsvRow[] {
-        const content = buffer.toString("utf-8");
-        const lines = content.split("\n").filter((line) => line.trim() !== "");
+        // Quote-aware on purpose: a WhatsApp message keeps its line breaks
+        // inside one quoted field, so splitting on every "\n" would read the
+        // second line of a message as a row with no comma and reject the file.
+        const records = parseCsvRecords(buffer.toString("utf-8"));
 
-        if (lines.length === 0) {
+        if (records.length === 0) {
             throw new BadRequestException("File is empty");
         }
 
-        const header = lines[0].toLowerCase();
-        const hasToColumn = header.includes("to");
-        const hasMessageColumn = header.includes("message");
+        const header = records[0].map((column) => column.trim().toLowerCase());
+        const toIndex = header.indexOf("to");
+        const messageIndex = header.indexOf("message");
 
-        if (!hasToColumn || !hasMessageColumn) {
+        if (toIndex === -1 || messageIndex === -1) {
             throw new BadRequestException(
-                `Missing required column. CSV must have 'to' and 'message' columns. Found: ${header}`,
+                `Missing required column. CSV must have 'to' and 'message' columns. Found: ${header.join(",")}`,
             );
         }
 
-        const rows: CsvRow[] = [];
-        const dataLines = lines.slice(1);
+        return records.slice(1).map((record, index) => {
+            const to = (record[toIndex] ?? "").trim();
+            // The message keeps its own whitespace: it is the body that ships.
+            const message = record[messageIndex] ?? "";
 
-        for (let i = 0; i < dataLines.length; i++) {
-            const line = dataLines[i].trim();
-            if (!line) continue;
-
-            const parts = line.split(",");
-            if (parts.length < 2) {
+            if (!to || !message.trim()) {
                 throw new BadRequestException(
-                    `Invalid row format at line ${i + 2}: expected "phone,message"`,
+                    `Invalid row ${index + 1}: expected a phone and a message`,
                 );
             }
 
-            const to = parts[0].trim();
-            const message = parts.slice(1).join(",").trim();
-
-            rows.push({ to, message });
-        }
-
-        return rows;
+            return { to, message };
+        });
     }
 
     private validatePhoneNumber(phone: string): boolean {

--- a/src/context/shared/utils/csv.utils.ts
+++ b/src/context/shared/utils/csv.utils.ts
@@ -1,0 +1,93 @@
+/**
+ * Minimal RFC 4180 CSV reader.
+ *
+ * The bulk upload used to read its CSV with content.split("\n"), which treats
+ * every newline as a row boundary. WhatsApp campaigns keep their line breaks
+ * inside one quoted field, so the second line of a message looked like a row
+ * without a comma and the upload failed with "Invalid row format".
+ *
+ * A newline only ends a record when it sits outside a quoted field.
+ */
+
+const DELIMITER = ",";
+const QUOTE = '"';
+
+/**
+ * Excel writes a UTF-8 BOM when it saves a CSV. Left in place it becomes part
+ * of the first header name, so a lookup for "to" would no longer find it.
+ */
+const BYTE_ORDER_MARK = 0xfeff;
+
+/**
+ * Parses CSV text into records of unescaped fields.
+ *
+ * Surrounding quotes are removed and doubled quotes collapse into one, so the
+ * returned values are ready to use. Blank records are dropped, and a CR that
+ * ends a line is normalized to LF so callers never see stray carriage returns.
+ *
+ * @param content Raw CSV text
+ * @returns One array of field values per record
+ */
+export const parseCsvRecords = (content: string): string[][] => {
+  if (!content) return [];
+
+  const text = content.charCodeAt(0) === BYTE_ORDER_MARK ? content.slice(1) : content;
+  const records: string[][] = [];
+  let fields: string[] = [];
+  let field = "";
+  let insideQuotes = false;
+
+  const endField = () => {
+    fields.push(field);
+    field = "";
+  };
+
+  const endRecord = () => {
+    endField();
+    // A record is blank when it holds nothing but empty fields, which is what
+    // a trailing newline or a stray blank line produces.
+    if (fields.some((value) => value.trim() !== "")) records.push(fields);
+    fields = [];
+  };
+
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index];
+
+    if (char === QUOTE) {
+      // A doubled quote inside a quoted field is an escaped quote: it belongs
+      // to the value and must not close the field.
+      if (insideQuotes && text[index + 1] === QUOTE) {
+        field += QUOTE;
+        index++;
+        continue;
+      }
+
+      insideQuotes = !insideQuotes;
+      continue;
+    }
+
+    if (insideQuotes) {
+      // Normalize CRLF that lives inside a quoted message to a plain LF.
+      if (char === "\r" && text[index + 1] === "\n") continue;
+      field += char;
+      continue;
+    }
+
+    if (char === DELIMITER) {
+      endField();
+      continue;
+    }
+
+    if (char === "\n" || char === "\r") {
+      if (char === "\r" && text[index + 1] === "\n") index++;
+      endRecord();
+      continue;
+    }
+
+    field += char;
+  }
+
+  endRecord();
+
+  return records;
+};

--- a/tests/unit/context/notifications/notifications.service.test.ts
+++ b/tests/unit/context/notifications/notifications.service.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { NotificationsService } from "../../../../src/context/notifications/notifications.service";
+
+/**
+ * Exercises the real parseCSV through the public bulkUpload seam.
+ *
+ * bulkUpload parses and validates the file BEFORE it reads its configuration,
+ * so an unconfigured service is a clean way to prove parsing succeeded: the
+ * request gets as far as "not configured" instead of dying on the file. That is
+ * exactly the regression that shipped — a multiline campaign was rejected with
+ * 'Invalid row format at line 3' before it ever left the gym backend.
+ */
+describe("NotificationsService.bulkUpload", () => {
+  const NOT_CONFIGURED = "Notifications service not configured";
+  const BYTE_ORDER_MARK = "﻿";
+  const CAMPAIGN = [
+    "*PLUSFIT A CORRER!!!*",
+    "",
+    "- Todos nosotros CARRERAS FIT vamos por los 7 km",
+    "- Circuito totalmente renovado.",
+    "",
+    "https://encarrera.uy/formulario",
+  ].join("\n");
+
+  /** Unconfigured on purpose, so parsing is what gets tested. */
+  function createService() {
+    return new NotificationsService({} as never, { get: () => undefined } as never);
+  }
+
+  function upload(csv: string, originalname = "campania.csv", mimetype = "text/csv") {
+    return createService().bulkUpload({
+      originalname,
+      mimetype,
+      buffer: Buffer.from(csv, "utf-8"),
+    });
+  }
+
+  function csvWith(message: string, phones = ["+59899123456"]) {
+    const quoted = `"${message.replace(/"/g, '""')}"`;
+    return ["to,message", ...phones.map((phone) => `${phone},${quoted}`)].join("\n");
+  }
+
+  describe("accepts what the dashboard exports", () => {
+    it("accepts a multiline campaign instead of rejecting the row format", async () => {
+      await expect(upload(csvWith(CAMPAIGN))).rejects.toThrow(NOT_CONFIGURED);
+    });
+
+    it("accepts a multiline campaign for many recipients", async () => {
+      const phones = Array.from({ length: 45 }, (_, i) => `+5989912${String(i).padStart(4, "0")}`);
+
+      await expect(upload(csvWith(CAMPAIGN, phones))).rejects.toThrow(NOT_CONFIGURED);
+    });
+
+    it("accepts a file Excel saved with a UTF-8 BOM", async () => {
+      await expect(upload(`${BYTE_ORDER_MARK}${csvWith(CAMPAIGN)}`)).rejects.toThrow(
+        NOT_CONFIGURED,
+      );
+    });
+
+    it("accepts a CRLF file", async () => {
+      await expect(upload(csvWith(CAMPAIGN).replace(/\n/g, "\r\n"))).rejects.toThrow(
+        NOT_CONFIGURED,
+      );
+    });
+
+    it("accepts a message holding commas, semicolons and quotes", async () => {
+      const message = 'Uno, dos; tres. Escribi "hola" al referente.';
+
+      await expect(upload(csvWith(message))).rejects.toThrow(NOT_CONFIGURED);
+    });
+
+    it("accepts a trailing newline after the last recipient", async () => {
+      await expect(upload(`${csvWith(CAMPAIGN)}\n`)).rejects.toThrow(NOT_CONFIGURED);
+    });
+  });
+
+  describe("accepts simple messages", () => {
+    it("accepts a one-word unquoted message", async () => {
+      await expect(upload("to,message\n+59899123456,Hola")).rejects.toThrow(NOT_CONFIGURED);
+    });
+
+    it("accepts an unquoted message with spaces", async () => {
+      await expect(upload("to,message\n+59899123456,Hola como estas")).rejects.toThrow(
+        NOT_CONFIGURED,
+      );
+    });
+
+    it("accepts several single-line recipients", async () => {
+      const csv = ["to,message", "+59899123456,Hola", "+59899123457,Chau"].join("\n");
+
+      await expect(upload(csv)).rejects.toThrow(NOT_CONFIGURED);
+    });
+
+    it("accepts a file mixing quoted multiline and plain messages", async () => {
+      const csv = [
+        "to,message",
+        "+59899123456,Hola",
+        '+59899123457,"uno\ndos"',
+        "+59899123458,Chau",
+      ].join("\n");
+
+      await expect(upload(csv)).rejects.toThrow(NOT_CONFIGURED);
+    });
+  });
+
+  describe("still rejects genuinely broken files", () => {
+    it("rejects a file with no rows", async () => {
+      await expect(upload("")).rejects.toThrow("File is empty");
+    });
+
+    it("rejects a file whose columns are wrong", async () => {
+      await expect(upload("telefono,texto\n+59899123456,hola")).rejects.toThrow(
+        "Missing required column",
+      );
+    });
+
+    it("rejects a row with a phone but no message", async () => {
+      await expect(upload("to,message\n+59899123456,")).rejects.toThrow("Invalid row 1");
+    });
+
+    it("rejects a row whose message is only whitespace", async () => {
+      await expect(upload('to,message\n+59899123456,"   "')).rejects.toThrow("Invalid row 1");
+    });
+
+    it("rejects a national phone that never got normalized", async () => {
+      await expect(upload("to,message\n099123456,Hola")).rejects.toThrow("Invalid phone format");
+    });
+
+    it("names the offending phone so the admin can fix the client", async () => {
+      await expect(upload("to,message\n+5491112345678,Hola")).rejects.toThrow("+5491112345678");
+    });
+
+    it("rejects a file over the thousand row limit", async () => {
+      const phones = Array.from({ length: 1001 }, (_, i) => `+5989912${String(i).padStart(4, "0")}`);
+
+      await expect(upload(csvWith("Hola", phones))).rejects.toThrow("exceeds 1000 row limit");
+    });
+
+    it("rejects a file that is neither named nor typed as csv", async () => {
+      await expect(
+        upload("to,message\n+59899123456,Hola", "campania.txt", "text/plain"),
+      ).rejects.toThrow("Only CSV files are allowed");
+    });
+
+    /**
+     * The extension and the mime type are checked with AND, so either one being
+     * csv is enough. Browsers do send application/vnd.ms-excel for a .csv, so
+     * relying on the mime type alone would reject legitimate uploads.
+     */
+    it("accepts a .csv whose mime type the browser got wrong", async () => {
+      await expect(
+        upload("to,message\n+59899123456,Hola", "campania.csv", "application/vnd.ms-excel"),
+      ).rejects.toThrow(NOT_CONFIGURED);
+    });
+
+    it("accepts a csv mime type even when the name lacks the extension", async () => {
+      await expect(
+        upload("to,message\n+59899123456,Hola", "campania", "text/csv"),
+      ).rejects.toThrow(NOT_CONFIGURED);
+    });
+  });
+});

--- a/tests/unit/context/shared/utils/csv.utils.test.ts
+++ b/tests/unit/context/shared/utils/csv.utils.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCsvRecords } from "../../../../../src/context/shared/utils/csv.utils";
+
+/**
+ * The bulk upload used to parse its CSV with content.split("\n"), which treats
+ * every newline as a row boundary. A WhatsApp message keeps its line breaks
+ * inside one quoted field, so the second line of a message looked like a row
+ * with no comma and the upload died with 'Invalid row format at line 3'.
+ */
+describe("parseCsvRecords", () => {
+  it("parses plain rows into fields", () => {
+    expect(parseCsvRecords("to,message\n+59899123456,hola")).toEqual([
+      ["to", "message"],
+      ["+59899123456", "hola"],
+    ]);
+  });
+
+  it("keeps a quoted multiline field in a single record", () => {
+    const content = 'to,message\n+59899123456,"linea uno\nlinea dos\nlinea tres"';
+
+    expect(parseCsvRecords(content)).toEqual([
+      ["to", "message"],
+      ["+59899123456", "linea uno\nlinea dos\nlinea tres"],
+    ]);
+  });
+
+  it("strips the surrounding quotes from a quoted field", () => {
+    expect(parseCsvRecords('to,message\n+59899123456,"hola"')[1]).toEqual([
+      "+59899123456",
+      "hola",
+    ]);
+  });
+
+  it("unescapes doubled quotes into a single quote", () => {
+    expect(parseCsvRecords('to,message\n+59899123456,"di ""hola"" fuerte"')[1]).toEqual([
+      "+59899123456",
+      'di "hola" fuerte',
+    ]);
+  });
+
+  it("keeps a comma that lives inside a quoted field", () => {
+    expect(parseCsvRecords('to,message\n+59899123456,"uno, dos, tres"')[1]).toEqual([
+      "+59899123456",
+      "uno, dos, tres",
+    ]);
+  });
+
+  it("handles CRLF row separators", () => {
+    expect(parseCsvRecords('to,message\r\n+59899123456,"hola"')).toEqual([
+      ["to", "message"],
+      ["+59899123456", "hola"],
+    ]);
+  });
+
+  it("preserves a CRLF that lives inside a quoted field as a line break", () => {
+    expect(parseCsvRecords('to,message\n+59899123456,"uno\r\ndos"')[1][1]).toBe("uno\ndos");
+  });
+
+  it("skips blank rows so a trailing newline adds nothing", () => {
+    expect(parseCsvRecords("to,message\n+59899123456,hola\n\n")).toEqual([
+      ["to", "message"],
+      ["+59899123456", "hola"],
+    ]);
+  });
+
+  it("returns an empty list for empty content", () => {
+    expect(parseCsvRecords("")).toEqual([]);
+    expect(parseCsvRecords("\n\n")).toEqual([]);
+  });
+
+  it("keeps an empty field as an empty string", () => {
+    expect(parseCsvRecords("to,message\n+59899123456,")[1]).toEqual(["+59899123456", ""]);
+  });
+
+  /**
+   * Excel and Google Sheets are the two tools a gym admin will open the export
+   * with, and both change the file on save. These cover what comes back.
+   */
+  describe("files that went through a spreadsheet", () => {
+    const BYTE_ORDER_MARK = "﻿";
+
+    it("strips a UTF-8 BOM so the first column is still named to", () => {
+      const records = parseCsvRecords(`${BYTE_ORDER_MARK}to,message\n+59899123456,hola`);
+
+      expect(records[0]).toEqual(["to", "message"]);
+      expect(records[1]).toEqual(["+59899123456", "hola"]);
+    });
+
+    it("strips a BOM in front of a multiline message", () => {
+      const records = parseCsvRecords(
+        `${BYTE_ORDER_MARK}to,message\n+59899123456,"uno\ndos"`,
+      );
+
+      expect(records[0][0]).toBe("to");
+      expect(records[1][1]).toBe("uno\ndos");
+    });
+
+    it("handles a lone CR as a row separator", () => {
+      expect(parseCsvRecords("to,message\r+59899123456,hola")).toEqual([
+        ["to", "message"],
+        ["+59899123456", "hola"],
+      ]);
+    });
+
+    it("keeps the column order the file declares", () => {
+      expect(parseCsvRecords('message,to\n"hola",+59899123456')).toEqual([
+        ["message", "to"],
+        ["hola", "+59899123456"],
+      ]);
+    });
+
+    it("keeps extra columns instead of dropping them", () => {
+      expect(parseCsvRecords("to,message,nombre\n+59899123456,hola,Ana")[1]).toEqual([
+        "+59899123456",
+        "hola",
+        "Ana",
+      ]);
+    });
+  });
+
+  describe("border cases", () => {
+    it("returns a single field when the row has no delimiter", () => {
+      expect(parseCsvRecords("to,message\n+59899123456")[1]).toEqual(["+59899123456"]);
+    });
+
+    it("reads an empty quoted field as an empty string", () => {
+      expect(parseCsvRecords('to,message\n+59899123456,""')[1]).toEqual([
+        "+59899123456",
+        "",
+      ]);
+    });
+
+    it("keeps a message made only of line breaks as whitespace", () => {
+      expect(parseCsvRecords('to,message\n+59899123456,"\n\n"')[1]).toEqual([
+        "+59899123456",
+        "\n\n",
+      ]);
+    });
+
+    it("keeps a quoted field that is only spaces", () => {
+      expect(parseCsvRecords('to,message\n+59899123456,"   "')[1]).toEqual([
+        "+59899123456",
+        "   ",
+      ]);
+    });
+
+    it("recovers the value from an unterminated quote instead of throwing", () => {
+      expect(parseCsvRecords('to,message\n+59899123456,"hola sin cerrar')[1]).toEqual([
+        "+59899123456",
+        "hola sin cerrar",
+      ]);
+    });
+
+    it("drops a row made only of delimiters", () => {
+      expect(parseCsvRecords("to,message\n,,\n+59899123456,hola")).toEqual([
+        ["to", "message"],
+        ["+59899123456", "hola"],
+      ]);
+    });
+
+    it("keeps emoji and accents intact", () => {
+      const message = "Vamos! 🏃‍♂️ inscripción abierta — ñandú";
+
+      expect(parseCsvRecords(`to,message\n+59899123456,"${message}"`)[1][1]).toBe(message);
+    });
+
+    it("handles a message longer than a thousand characters", () => {
+      const message = `${"linea\n".repeat(200)}fin`;
+
+      const records = parseCsvRecords(`to,message\n+59899123456,"${message}"`);
+
+      expect(records.length).toBe(2);
+      expect(records[1][1]).toBe(message);
+    });
+
+    it("keeps a url with its slashes and query string", () => {
+      const url = "https://encarrera.uy/form?grupo=fit&ref=1";
+
+      expect(parseCsvRecords(`to,message\n+59899123456,"Anotate: ${url}"`)[1][1]).toBe(
+        `Anotate: ${url}`,
+      );
+    });
+
+    it("parses two hundred recipients with multiline messages", () => {
+      const message = '"uno\ndos\ntres"';
+      const rows = Array.from({ length: 200 }, (_, i) => `+5989912${i},${message}`);
+
+      const records = parseCsvRecords(["to,message", ...rows].join("\n"));
+
+      expect(records.length).toBe(201);
+      expect(records.every((record) => record.length === 2)).toBe(true);
+    });
+  });
+
+  describe("simple messages", () => {
+    it("parses a one-word unquoted message", () => {
+      expect(parseCsvRecords("to,message\n+59899123456,Hola")[1]).toEqual([
+        "+59899123456",
+        "Hola",
+      ]);
+    });
+
+    it("parses an unquoted message with spaces", () => {
+      expect(parseCsvRecords("to,message\n+59899123456,Hola como estas")[1]).toEqual([
+        "+59899123456",
+        "Hola como estas",
+      ]);
+    });
+
+    it("parses several single-line recipients", () => {
+      const records = parseCsvRecords(
+        ["to,message", "+59899123456,Hola", "+59899123457,Chau", "+59899123458,Buenas"].join(
+          "\n",
+        ),
+      );
+
+      expect(records.slice(1).map((record) => record[1])).toEqual([
+        "Hola",
+        "Chau",
+        "Buenas",
+      ]);
+    });
+
+    it("parses a mix of quoted and unquoted messages in one file", () => {
+      const records = parseCsvRecords(
+        ["to,message", "+59899123456,Hola", '+59899123457,"uno\ndos"', "+59899123458,Chau"].join(
+          "\n",
+        ),
+      );
+
+      expect(records.length).toBe(4);
+      expect(records.slice(1).map((record) => record[1])).toEqual([
+        "Hola",
+        "uno\ndos",
+        "Chau",
+      ]);
+    });
+  });
+
+  it("counts one record per recipient across a full campaign export", () => {
+    const message = '"*PLUSFIT A CORRER!!!*\n\n- Todos vamos por los 7 km\n- Medallas"';
+    const content = [
+      "to,message",
+      `+59899123456,${message}`,
+      `+59899123457,${message}`,
+      `+59899123458,${message}`,
+    ].join("\n");
+
+    const records = parseCsvRecords(content);
+
+    expect(records.length).toBe(4);
+    expect(records.slice(1).map((record) => record[0])).toEqual([
+      "+59899123456",
+      "+59899123457",
+      "+59899123458",
+    ]);
+    expect(records[1][1]).toBe("*PLUSFIT A CORRER!!!*\n\n- Todos vamos por los 7 km\n- Medallas");
+  });
+});


### PR DESCRIPTION
## Problem

Uploading an export whose message spans several lines failed with:

```
Invalid row format at line 3: expected "phone,message"
```

`parseCSV` read the file with `content.split("\n")`, which treats every newline as a row boundary. That is only true when no field contains one — and a WhatsApp message with paragraphs or a bullet list lives inside a single quoted field, newlines included. So line 2 of a message was read as a row with no comma, and the whole upload was rejected.

This was the third quote-blind CSV reader in the same pipeline. The other two are fixed in sibling PRs.

## Change

Add `parseCsvRecords` in `shared/utils/csv.utils.ts` — a minimal RFC 4180 reader:

- a newline ends a record only outside a quoted field
- a doubled quote is content, not a field boundary
- a UTF-8 BOM is stripped, because Excel writes one on save and it would otherwise become part of the first column's name

`parseCSV` now uses it, and reads the header by column name rather than substring matching, so `message,to` works and a column literally named `to_something` no longer satisfies the `to` check.

The message keeps its own whitespace — it is the body that ships, not a token to tidy up.

## Verification

Built test-first. 50 new tests:

| Spec | Tests | Covers |
| --- | --- | --- |
| `csv.utils.test.ts` | 30 | quoted multiline fields, escaped quotes, BOM, lone CR, column order, extra columns, unterminated quote, emoji, 200 recipients, simple messages |
| `notifications.service.test.ts` | 20 | `parseCSV` through the public `bulkUpload` seam: the multiline campaign that used to fail, Excel BOM, CRLF, simple bodies, and the rejections that must still happen |

`notifications.service.test.ts` exercises the real parser through `bulkUpload` by leaving the service unconfigured: parsing and validation run before the config is read, so reaching `Notifications service not configured` proves the file parsed. The regression is exactly that this stopped being `Invalid row format`.

```
Test Files  3 passed (3)
     Tests  77 passed (77)
```

`tsc --noEmit` clean.

## Base

Targets `hotfix/lint-fixes` rather than `main` because it builds on that branch's changes to this same file. Merges after #167.
