### PR TITLE
feat(notifications): bulk send with {nombre} personalization and test send

### DIFF
--- a/src/context/notifications/dto/bulk-send.dto.ts
+++ b/src/context/notifications/dto/bulk-send.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+    ArrayMaxSize,
+    ArrayNotEmpty,
+    IsArray,
+    IsMongoId,
+    IsNotEmpty,
+    IsString,
+    Matches,
+    MaxLength,
+} from "class-validator";
+
+/**
+ * File-less bulk send. The dashboard posts the client ids it selected and the
+ * message; the backend resolves those ids to phones, so the browser never gets
+ * to name a phone number itself.
+ */
+export class BulkSendDto {
+    @ApiProperty({
+        example: ["507f1f77bcf86cd799439011"],
+        description: "Ids of the clients selected in the dashboard",
+        type: [String],
+    })
+    @IsArray()
+    @ArrayNotEmpty()
+    @ArrayMaxSize(1000)
+    // Guards the Mongo query: a malformed id would raise a CastError inside find().
+    @IsMongoId({ each: true })
+    clientIds!: string[];
+
+    @ApiProperty({
+        example: "Hello from Plus Fit!",
+        description: "Message sent to every recipient; line breaks are preserved",
+        maxLength: 4096,
+    })
+    @IsString()
+    @IsNotEmpty()
+    // IsNotEmpty accepts a string of blanks, which is not a message.
+    @Matches(/\S/, { message: "message must not be blank" })
+    @MaxLength(4096)
+    message!: string;
+}
+
+export type SkippedReason = "not_found" | "no_phone" | "invalid_phone" | "duplicate_phone";
+
+export interface SkippedRecipient {
+    clientId: string;
+    name: string | null;
+    reason: SkippedReason;
+}
+
+export interface BulkSendResponse {
+    batchId: string;
+    /** Recipients actually enqueued. */
+    total: number;
+    /** Client ids received, so the dashboard can show selected vs sent. */
+    requested: number;
+    skipped: SkippedRecipient[];
+}

--- a/src/context/notifications/dto/test-send.dto.ts
+++ b/src/context/notifications/dto/test-send.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString, Matches, MaxLength } from "class-validator";
+
+/**
+ * A test send: the campaign body, but to the admin's own phone. The frontend
+ * ships the message with {nombre} already replaced by a sample, so the test
+ * reads exactly like the real thing.
+ */
+export class TestSendDto {
+    @ApiProperty({
+        example: "099123456",
+        description: "Phone that receives the test, in any format the gym uses",
+    })
+    @IsString()
+    @IsNotEmpty()
+    phone!: string;
+
+    @ApiProperty({
+        example: "Hola Ana!",
+        description: "Message body; line breaks are preserved",
+        maxLength: 4096,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @Matches(/\S/, { message: "message must not be blank" })
+    @MaxLength(4096)
+    message!: string;
+}
+
+export interface TestSendResponse {
+    jobId: string;
+    status: string;
+    scheduledFor: string;
+}

--- a/src/context/notifications/notifications.controller.ts
+++ b/src/context/notifications/notifications.controller.ts
@@ -25,6 +25,7 @@ import { RolesGuard } from "@/src/context/shared/guards/roles/roles.guard";
 
 import { BulkSendDto } from "./dto/bulk-send.dto";
 import { CreateNotificationDto } from "./dto/create-notification.dto";
+import { TestSendDto } from "./dto/test-send.dto";
 import { UpdateNotificationDto } from "./dto/update-notification.dto";
 import { NotificationsService } from "./notifications.service";
 import { InactivityCheckService } from "./services/inactivity-check.service";
@@ -123,6 +124,18 @@ export class NotificationsController {
     @HttpCode(HttpStatus.ACCEPTED)
     async bulkSend(@Body() bulkSendDto: BulkSendDto) {
         return await this.notificationsService.bulkSend(bulkSendDto);
+    }
+
+    @Post("test-send")
+    @ApiOperation({
+        summary: "Send the campaign body to a single phone as a test",
+    })
+    @ApiResponse({ status: 201, description: "Test message queued" })
+    @ApiResponse({ status: 400, description: "Invalid phone" })
+    @Roles(Role.Admin)
+    @UseGuards(RolesGuard)
+    async testSend(@Body() testSendDto: TestSendDto) {
+        return await this.notificationsService.testSend(testSendDto);
     }
 
     @Get("bulk-status/:batchId")

--- a/src/context/notifications/notifications.controller.ts
+++ b/src/context/notifications/notifications.controller.ts
@@ -4,18 +4,26 @@ import {
     Controller,
     Delete,
     Get,
+    HttpCode,
+    HttpStatus,
     Param,
     Patch,
     Post,
     Query,
     Req,
     Request,
+    UseGuards,
 } from "@nestjs/common";
 import { ApiConsumes, ApiTags } from "@nestjs/swagger";
 import { ApiOperation, ApiResponse } from "@nestjs/swagger";
 import busboy from "busboy";
 import type { FastifyRequest } from "fastify";
 
+import { Role } from "@/src/context/shared/constants/roles.constant";
+import { Roles } from "@/src/context/shared/guards/roles/roles.decorator";
+import { RolesGuard } from "@/src/context/shared/guards/roles/roles.guard";
+
+import { BulkSendDto } from "./dto/bulk-send.dto";
 import { CreateNotificationDto } from "./dto/create-notification.dto";
 import { UpdateNotificationDto } from "./dto/update-notification.dto";
 import { NotificationsService } from "./notifications.service";
@@ -102,6 +110,19 @@ export class NotificationsController {
         });
 
         return await this.notificationsService.bulkUpload(file);
+    }
+
+    @Post("bulk-send")
+    @ApiOperation({
+        summary: "Send a bulk WhatsApp message to selected clients (no file)",
+    })
+    @ApiResponse({ status: 202, description: "Bulk processing started" })
+    @ApiResponse({ status: 400, description: "No reachable recipients" })
+    @Roles(Role.Admin)
+    @UseGuards(RolesGuard)
+    @HttpCode(HttpStatus.ACCEPTED)
+    async bulkSend(@Body() bulkSendDto: BulkSendDto) {
+        return await this.notificationsService.bulkSend(bulkSendDto);
     }
 
     @Get("bulk-status/:batchId")

--- a/src/context/notifications/notifications.service.ts
+++ b/src/context/notifications/notifications.service.ts
@@ -7,11 +7,18 @@ import {
     NotFoundException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { InjectModel } from "@nestjs/mongoose";
 import axios from "axios";
 import FormData from "form-data";
+import { Model } from "mongoose";
 
 import { parseCsvRecords } from "@/src/context/shared/utils/csv.utils";
+import {
+    normalizeWhatsAppMessage,
+    toUruguayE164,
+} from "@/src/context/shared/utils/whatsapp-message.utils";
 
+import { BulkSendDto, BulkSendResponse, SkippedRecipient } from "./dto/bulk-send.dto";
 import { BulkStatusResponseDto } from "./dto/bulk-status.dto";
 import { BulkUploadResponseDto } from "./dto/bulk-upload.dto";
 import { CreateNotificationDto } from "./dto/create-notification.dto";
@@ -36,7 +43,114 @@ export class NotificationsService {
         @Inject(NOTIFICATION_REPOSITORY)
         private readonly notificationRepository: any,
         private readonly configService: ConfigService,
+        @InjectModel("Client")
+        private readonly clientModel: Model<any>,
     ) {}
+
+    /**
+     * Sends one message to a list of selected clients without any file.
+     *
+     * This owns the whole resolution step: ids come from the dashboard, phones
+     * come from the database. Clients that cannot be reached are dropped and
+     * reported by name — the notifications service rejects an entire batch on
+     * the first unusable phone, so one bad record would otherwise kill the
+     * whole campaign.
+     */
+    async bulkSend(dto: BulkSendDto): Promise<BulkSendResponse> {
+        const { url, apiKey } = this.requireNotificationsServiceConfig();
+
+        const clients = await this.clientModel
+            .find({ _id: { $in: dto.clientIds } })
+            .exec();
+        const byId = new Map(clients.map((client: any) => [String(client._id), client]));
+
+        const recipients: string[] = [];
+        const skipped: SkippedRecipient[] = [];
+        const seenPhones = new Set<string>();
+
+        for (const clientId of dto.clientIds) {
+            const client = byId.get(clientId);
+
+            if (!client) {
+                skipped.push({ clientId, name: null, reason: "not_found" });
+                continue;
+            }
+
+            const name = client.userInfo?.name || client.email || null;
+            const rawPhone = client.userInfo?.phone;
+
+            if (!rawPhone) {
+                skipped.push({ clientId, name, reason: "no_phone" });
+                continue;
+            }
+
+            const phone = toUruguayE164(rawPhone);
+            if (!phone) {
+                skipped.push({ clientId, name, reason: "invalid_phone" });
+                continue;
+            }
+
+            // Two clients sharing a handset would get the campaign twice.
+            if (seenPhones.has(phone)) {
+                skipped.push({ clientId, name, reason: "duplicate_phone" });
+                continue;
+            }
+
+            seenPhones.add(phone);
+            recipients.push(phone);
+        }
+
+        if (recipients.length === 0) {
+            throw new BadRequestException(
+                "No reachable recipients: every selected client is missing a valid phone",
+            );
+        }
+
+        try {
+            const response = await axios.post(
+                `${url}/notifications/bulk-direct`,
+                { to: recipients, message: normalizeWhatsAppMessage(dto.message) },
+                { headers: { "X-Api-Key": apiKey }, timeout: 30000 },
+            );
+
+            return {
+                batchId: response.data.batchId,
+                total: response.data.total,
+                requested: dto.clientIds.length,
+                skipped,
+            };
+        } catch (error: any) {
+            throw this.toProxyException(error, "Error enqueuing bulk send");
+        }
+    }
+
+    private requireNotificationsServiceConfig() {
+        const url = this.configService.get<string>("NOTIFICATIONS_SERVICE_URL");
+        const apiKey = this.configService.get<string>("NOTIFICATIONS_SERVICE_API_KEY");
+
+        if (!url || !apiKey) {
+            throw new HttpException(
+                "Notifications service not configured",
+                HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+
+        return { url, apiKey };
+    }
+
+    /**
+     * Keeps the reason the notifications service gave us. axios replaces it
+     * with a generic "Request failed with status code 401", which is what made
+     * an api key scope mismatch undiagnosable from the dashboard.
+     */
+    private toProxyException(error: any, fallback: string) {
+        const message = error.response?.data?.message || error.message || fallback;
+
+        return new HttpException(
+            message,
+            error.response?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+    }
 
     private parseCSV(buffer: Buffer): CsvRow[] {
         // Quote-aware on purpose: a WhatsApp message keeps its line breaks

--- a/src/context/notifications/notifications.service.ts
+++ b/src/context/notifications/notifications.service.ts
@@ -14,11 +14,14 @@ import { Model } from "mongoose";
 
 import { parseCsvRecords } from "@/src/context/shared/utils/csv.utils";
 import {
+    interpolateName,
+    NAME_TOKEN,
     normalizeWhatsAppMessage,
     toUruguayE164,
 } from "@/src/context/shared/utils/whatsapp-message.utils";
 
 import { BulkSendDto, BulkSendResponse, SkippedRecipient } from "./dto/bulk-send.dto";
+import { TestSendDto, TestSendResponse } from "./dto/test-send.dto";
 import { BulkStatusResponseDto } from "./dto/bulk-status.dto";
 import { BulkUploadResponseDto } from "./dto/bulk-upload.dto";
 import { CreateNotificationDto } from "./dto/create-notification.dto";
@@ -64,7 +67,7 @@ export class NotificationsService {
             .exec();
         const byId = new Map(clients.map((client: any) => [String(client._id), client]));
 
-        const recipients: string[] = [];
+        const recipients: { phone: string; name: string }[] = [];
         const skipped: SkippedRecipient[] = [];
         const seenPhones = new Set<string>();
 
@@ -97,7 +100,7 @@ export class NotificationsService {
             }
 
             seenPhones.add(phone);
-            recipients.push(phone);
+            recipients.push({ phone, name: name ?? "" });
         }
 
         if (recipients.length === 0) {
@@ -106,12 +109,24 @@ export class NotificationsService {
             );
         }
 
+        // {nombre} switches the payload to per-recipient items with the name
+        // already interpolated: the notifications service only knows phones,
+        // so names can never be resolved further downstream than here.
+        const template = normalizeWhatsAppMessage(dto.message);
+        const payload = template.includes(NAME_TOKEN)
+            ? {
+                  items: recipients.map(({ phone, name }) => ({
+                      to: phone,
+                      message: interpolateName(template, name),
+                  })),
+              }
+            : { to: recipients.map(({ phone }) => phone), message: template };
+
         try {
-            const response = await axios.post(
-                `${url}/notifications/bulk-direct`,
-                { to: recipients, message: normalizeWhatsAppMessage(dto.message) },
-                { headers: { "X-Api-Key": apiKey }, timeout: 30000 },
-            );
+            const response = await axios.post(`${url}/notifications/bulk-direct`, payload, {
+                headers: { "X-Api-Key": apiKey },
+                timeout: 30000,
+            });
 
             return {
                 batchId: response.data.batchId,
@@ -121,6 +136,42 @@ export class NotificationsService {
             };
         } catch (error: any) {
             throw this.toProxyException(error, "Error enqueuing bulk send");
+        }
+    }
+
+    /**
+     * Sends the campaign body to one phone — the admin's — through the
+     * individual send endpoint. Same normalization as the real bulk, so what
+     * arrives on the test handset is byte-for-byte what clients would get.
+     */
+    async testSend(dto: TestSendDto): Promise<TestSendResponse> {
+        const { url, apiKey } = this.requireNotificationsServiceConfig();
+
+        const phone = toUruguayE164(dto.phone);
+        if (!phone) {
+            throw new BadRequestException(
+                "Invalid phone: expected an Uruguayan mobile number (e.g. 099123456)",
+            );
+        }
+
+        try {
+            const response = await axios.post(
+                `${url}/notifications/send`,
+                {
+                    channel: "whatsapp",
+                    to: phone,
+                    message: normalizeWhatsAppMessage(dto.message),
+                },
+                { headers: { "X-Api-Key": apiKey }, timeout: 15000 },
+            );
+
+            return {
+                jobId: response.data.jobId,
+                status: response.data.status,
+                scheduledFor: response.data.scheduledFor,
+            };
+        } catch (error: any) {
+            throw this.toProxyException(error, "Error sending test message");
         }
     }
 

--- a/src/context/shared/utils/whatsapp-message.utils.ts
+++ b/src/context/shared/utils/whatsapp-message.utils.ts
@@ -121,3 +121,20 @@ export const toUruguayE164 = (raw: string): string | null => {
 
   return `+${URUGUAY_COUNTRY_CODE}${national}`;
 };
+
+/** The one personalization token the campaign composer understands. */
+export const NAME_TOKEN = "{nombre}";
+
+/**
+ * Replaces every {nombre} token with the recipient's display name.
+ *
+ * Uses split/join instead of String.replace on purpose: a name containing "$&"
+ * or "$'" would trigger replace()'s dollar-pattern expansion and corrupt the
+ * message.
+ *
+ * @param template The campaign body, already normalized
+ * @param name The recipient's display name
+ * @returns The personalized message
+ */
+export const interpolateName = (template: string, name: string): string =>
+  template.split(NAME_TOKEN).join(name);

--- a/tests/unit/context/notifications/bulk-send.dto.test.ts
+++ b/tests/unit/context/notifications/bulk-send.dto.test.ts
@@ -1,0 +1,91 @@
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { describe, expect, it } from "vitest";
+
+import { BulkSendDto } from "../../../../src/context/notifications/dto/bulk-send.dto";
+
+/**
+ * Contract for the file-less bulk send. The dashboard posts the client ids it
+ * selected plus the message; the backend owns resolving those ids to phones, so
+ * the browser never gets to name a phone number itself.
+ */
+describe("BulkSendDto", () => {
+  const ID_A = "507f1f77bcf86cd799439011";
+  const ID_B = "507f1f77bcf86cd799439012";
+
+  async function errorsFor(payload: Record<string, unknown>) {
+    return validate(plainToInstance(BulkSendDto, payload));
+  }
+
+  function propertiesInError(errors: { property: string }[]) {
+    return errors.map((error) => error.property);
+  }
+
+  it("accepts client ids and a message", async () => {
+    const errors = await errorsFor({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("accepts a multiline campaign message", async () => {
+    const message = ["*PLUSFIT A CORRER!!!*", "", "- Todos vamos por los 7 km"].join("\n");
+
+    const errors = await errorsFor({ clientIds: [ID_A], message });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects an empty selection", async () => {
+    const errors = await errorsFor({ clientIds: [], message: "Hola" });
+
+    expect(propertiesInError(errors)).toContain("clientIds");
+  });
+
+  it("rejects a missing selection", async () => {
+    const errors = await errorsFor({ message: "Hola" });
+
+    expect(propertiesInError(errors)).toContain("clientIds");
+  });
+
+  /**
+   * Guards the Mongo query: an id that is not a valid ObjectId would make
+   * find({ _id: { $in: ids } }) throw a CastError deep in the service.
+   */
+  it("rejects an id that is not a valid mongo id", async () => {
+    const errors = await errorsFor({ clientIds: [ID_A, "not-an-id"], message: "Hola" });
+
+    expect(propertiesInError(errors)).toContain("clientIds");
+  });
+
+  it("rejects a selection over a thousand clients", async () => {
+    const clientIds = Array.from({ length: 1001 }, () => ID_A);
+
+    const errors = await errorsFor({ clientIds, message: "Hola" });
+
+    expect(propertiesInError(errors)).toContain("clientIds");
+  });
+
+  it("rejects an empty message", async () => {
+    const errors = await errorsFor({ clientIds: [ID_A], message: "" });
+
+    expect(propertiesInError(errors)).toContain("message");
+  });
+
+  it("rejects a whitespace-only message", async () => {
+    const errors = await errorsFor({ clientIds: [ID_A], message: "   \n  " });
+
+    expect(propertiesInError(errors)).toContain("message");
+  });
+
+  it("rejects a message over 4096 characters", async () => {
+    const errors = await errorsFor({ clientIds: [ID_A], message: "a".repeat(4097) });
+
+    expect(propertiesInError(errors)).toContain("message");
+  });
+
+  it("accepts a message of exactly 4096 characters", async () => {
+    const errors = await errorsFor({ clientIds: [ID_A], message: "a".repeat(4096) });
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/tests/unit/context/notifications/bulk-send.test.ts
+++ b/tests/unit/context/notifications/bulk-send.test.ts
@@ -1,0 +1,375 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationsService } from "../../../../src/context/notifications/notifications.service";
+
+vi.mock("axios");
+
+/**
+ * bulkSend replaces the CSV download/upload round trip. The dashboard sends the
+ * client ids it selected; this service owns turning those into E.164 phones,
+ * reporting who could not be reached, and proxying JSON to the notifications
+ * service. No file is written, uploaded or parsed anywhere in the flow.
+ */
+describe("NotificationsService.bulkSend", () => {
+  const SERVICE_URL = "http://localhost:3000";
+  const API_KEY = "pf_test_key";
+  const BULK_DIRECT_URL = `${SERVICE_URL}/notifications/bulk-direct`;
+
+  const ID_A = "507f1f77bcf86cd799439011";
+  const ID_B = "507f1f77bcf86cd799439012";
+  const ID_C = "507f1f77bcf86cd799439013";
+  const MISSING_ID = "507f1f77bcf86cd7994390ff";
+
+  const CAMPAIGN = ["*PLUSFIT A CORRER!!!*", "", "-Todos vamos por los 7 km"].join("\r\n");
+  const NORMALIZED_CAMPAIGN = [
+    "*PLUSFIT A CORRER!!!*",
+    "",
+    "- Todos vamos por los 7 km",
+  ].join("\n");
+
+  /** Shaped like a lean Client document: phone lives at userInfo.phone. */
+  function client(id: string, phone?: string, name = "Ana Perez") {
+    return { _id: id, email: `${name.split(" ")[0]}@mail.com`, userInfo: { name, phone } };
+  }
+
+  function createService(clients: ReturnType<typeof client>[], configured = true) {
+    const clientModel = {
+      find: vi.fn().mockReturnValue({ exec: vi.fn().mockResolvedValue(clients) }),
+    };
+    const configService = {
+      get: vi.fn().mockImplementation((key: string) => {
+        if (!configured) return undefined;
+        if (key === "NOTIFICATIONS_SERVICE_URL") return SERVICE_URL;
+        if (key === "NOTIFICATIONS_SERVICE_API_KEY") return API_KEY;
+        return undefined;
+      }),
+    };
+
+    const service = new NotificationsService(
+      {} as never,
+      configService as never,
+      clientModel as never,
+    );
+
+    return { service, clientModel, configService };
+  }
+
+  function acceptWith(batchId = "batch-1", total = 1) {
+    vi.mocked(axios.post).mockResolvedValue({ data: { batchId, total } });
+  }
+
+  /** Mirrors an axios error: the real reason lives in response.data.message. */
+  function rejectWith(status: number, message: string) {
+    vi.mocked(axios.post).mockRejectedValue({
+      message: `Request failed with status code ${status}`,
+      response: { status, data: { message } },
+    });
+  }
+
+  function postedBody() {
+    return vi.mocked(axios.post).mock.calls[0][1] as { to: string[]; message: string };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolving the selection into recipients", () => {
+    it("posts the normalized phone of every selected client", async () => {
+      acceptWith("batch-1", 2);
+      const { service } = createService([
+        client(ID_A, "099123456"),
+        client(ID_B, "+59899123457"),
+      ]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(postedBody().to).toEqual(["+59899123456", "+59899123457"]);
+      expect(result.batchId).toBe("batch-1");
+      expect(result.total).toBe(2);
+      expect(result.skipped).toEqual([]);
+    });
+
+    it("normalizes the messy formats the gym database actually holds", async () => {
+      acceptWith("batch-1", 4);
+      const { service } = createService([
+        client(ID_A, "099 123 456"),
+        client(ID_B, "(099) 123-457"),
+        client(ID_C, "59899123458"),
+        client(MISSING_ID, "99123459"),
+      ]);
+
+      await service.bulkSend({
+        clientIds: [ID_A, ID_B, ID_C, MISSING_ID],
+        message: "Hola",
+      });
+
+      expect(postedBody().to).toEqual([
+        "+59899123456",
+        "+59899123457",
+        "+59899123458",
+        "+59899123459",
+      ]);
+    });
+
+    it("queries only the selected ids", async () => {
+      acceptWith();
+      const { service, clientModel } = createService([client(ID_A, "099123456")]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: "Hola" });
+
+      expect(clientModel.find).toHaveBeenCalledWith({ _id: { $in: [ID_A] } });
+    });
+
+    it("reports how many clients were requested alongside what was sent", async () => {
+      acceptWith("batch-1", 1);
+      const { service } = createService([client(ID_A, "099123456"), client(ID_B)]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(result.requested).toBe(2);
+      expect(result.total).toBe(1);
+    });
+  });
+
+  /**
+   * The notifications service rejects an entire upload on the first unusable
+   * phone, so unreachable clients are dropped here — but never silently. The
+   * admin needs names to go fix the records.
+   */
+  describe("reporting who could not be reached", () => {
+    it("skips a client that has no phone at all", async () => {
+      acceptWith("batch-1", 1);
+      const { service } = createService([
+        client(ID_A, "099123456"),
+        client(ID_B, undefined, "Juan Gomez"),
+      ]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(postedBody().to).toEqual(["+59899123456"]);
+      expect(result.skipped).toEqual([
+        { clientId: ID_B, name: "Juan Gomez", reason: "no_phone" },
+      ]);
+    });
+
+    it("skips a phone that cannot become a valid E.164 number", async () => {
+      acceptWith("batch-1", 1);
+      const { service } = createService([
+        client(ID_A, "099123456"),
+        client(ID_B, "123", "Juan Gomez"),
+      ]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(postedBody().to).toEqual(["+59899123456"]);
+      expect(result.skipped).toEqual([
+        { clientId: ID_B, name: "Juan Gomez", reason: "invalid_phone" },
+      ]);
+    });
+
+    it("skips an id that no longer exists in the database", async () => {
+      acceptWith("batch-1", 1);
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      const result = await service.bulkSend({
+        clientIds: [ID_A, MISSING_ID],
+        message: "Hola",
+      });
+
+      expect(result.skipped).toEqual([
+        { clientId: MISSING_ID, name: null, reason: "not_found" },
+      ]);
+    });
+
+    /**
+     * Two clients sharing a phone would otherwise receive the campaign twice on
+     * the same handset. The first one wins and the collapse is reported, so the
+     * admin understands why 50 selected became 49 sent.
+     */
+    it("collapses two clients that share the same phone", async () => {
+      acceptWith("batch-1", 1);
+      const { service } = createService([
+        client(ID_A, "099123456", "Ana Perez"),
+        client(ID_B, "099 123 456", "Juan Gomez"),
+      ]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(postedBody().to).toEqual(["+59899123456"]);
+      expect(result.skipped).toEqual([
+        { clientId: ID_B, name: "Juan Gomez", reason: "duplicate_phone" },
+      ]);
+    });
+
+    it("falls back to the email when the client has no name", async () => {
+      acceptWith("batch-1", 1);
+      const nameless = { _id: ID_B, email: "sinnombre@mail.com", userInfo: {} };
+      const { service } = createService([client(ID_A, "099123456"), nameless as never]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(result.skipped[0].name).toBe("sinnombre@mail.com");
+    });
+
+    it("refuses to send when every selected client is unreachable", async () => {
+      const { service } = createService([client(ID_A), client(ID_B, "123")]);
+
+      await expect(
+        service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" }),
+      ).rejects.toThrow("No reachable recipients");
+
+      expect(axios.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("preparing the message", () => {
+    it("normalizes the message before proxying it", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: CAMPAIGN });
+
+      expect(postedBody().message).toBe(NORMALIZED_CAMPAIGN);
+    });
+
+    it("keeps the line breaks of a multiline campaign", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: CAMPAIGN });
+
+      expect(postedBody().message.split("\n")).toHaveLength(3);
+      expect(postedBody().message).not.toContain("\r");
+    });
+
+    it("sends one message for the whole batch, not one per client", async () => {
+      acceptWith("batch-1", 2);
+      const { service } = createService([
+        client(ID_A, "099123456"),
+        client(ID_B, "099123457"),
+      ]);
+
+      await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(typeof postedBody().message).toBe("string");
+      expect(postedBody().to).toHaveLength(2);
+    });
+  });
+
+  describe("talking to the notifications service", () => {
+    it("posts to the bulk-direct endpoint with the api key", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: "Hola" });
+
+      expect(axios.post).toHaveBeenCalledWith(
+        BULK_DIRECT_URL,
+        expect.objectContaining({ to: ["+59899123456"], message: "Hola" }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ "X-Api-Key": API_KEY }),
+        }),
+      );
+    });
+
+    it("fails clearly when the notifications service is not configured", async () => {
+      const { service } = createService([client(ID_A, "099123456")], false);
+
+      await expect(
+        service.bulkSend({ clientIds: [ID_A], message: "Hola" }),
+      ).rejects.toThrow("Notifications service not configured");
+
+      expect(axios.post).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The WhatsApp status proxy swallowed the real reason behind axios's
+     * generic "Request failed with status code 401", which made a scope
+     * mismatch undiagnosable. This path must surface the service's own message.
+     */
+    it("surfaces the real reason instead of the generic axios message", async () => {
+      rejectWith(401, "Insufficient scopes (requires one of: bulk, admin)");
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await expect(
+        service.bulkSend({ clientIds: [ID_A], message: "Hola" }),
+      ).rejects.toThrow("Insufficient scopes");
+    });
+
+    it("surfaces the daily cap rejection", async () => {
+      rejectWith(429, "Daily message cap reached");
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await expect(
+        service.bulkSend({ clientIds: [ID_A], message: "Hola" }),
+      ).rejects.toThrow("Daily message cap reached");
+    });
+
+    it("falls back to the axios message when the service sends no body", async () => {
+      vi.mocked(axios.post).mockRejectedValue({ message: "connect ECONNREFUSED" });
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await expect(
+        service.bulkSend({ clientIds: [ID_A], message: "Hola" }),
+      ).rejects.toThrow("connect ECONNREFUSED");
+    });
+
+    /**
+     * Contract fixtures shared with the notifications service, whose
+     * BulkDirectDto spec asserts these exact values. They are duplicated on
+     * purpose: neither test runner can import across the two repos, so the
+     * boundary is pinned from both sides. If one drifts, one suite goes red.
+     */
+    it("emits the exact payload shape the notifications service accepts", async () => {
+      acceptWith("batch-1", 6);
+      const { service } = createService([
+        client(ID_A, "099 123 456"),
+        client(ID_B, "(099) 123-457"),
+        client(ID_C, "+59899123458"),
+        { _id: "507f1f77bcf86cd799439014", email: "d@mail.com", userInfo: { name: "D", phone: "099123459" } },
+        { _id: "507f1f77bcf86cd799439015", email: "e@mail.com", userInfo: { name: "E", phone: "59899123460" } },
+        { _id: "507f1f77bcf86cd799439016", email: "f@mail.com", userInfo: { name: "F", phone: "99123461" } },
+      ]);
+
+      await service.bulkSend({
+        clientIds: [
+          ID_A,
+          ID_B,
+          ID_C,
+          "507f1f77bcf86cd799439014",
+          "507f1f77bcf86cd799439015",
+          "507f1f77bcf86cd799439016",
+        ],
+        message: "Hola",
+      });
+
+      expect(postedBody().to).toEqual([
+        "+59899123456",
+        "+59899123457",
+        "+59899123458",
+        "+59899123459",
+        "+59899123460",
+        "+59899123461",
+      ]);
+    });
+
+    it("still reports the skipped clients when the send succeeds", async () => {
+      acceptWith("batch-9", 1);
+      const { service } = createService([
+        client(ID_A, "099123456"),
+        client(ID_B, undefined, "Juan Gomez"),
+      ]);
+
+      const result = await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola" });
+
+      expect(result).toEqual({
+        batchId: "batch-9",
+        total: 1,
+        requested: 2,
+        skipped: [{ clientId: ID_B, name: "Juan Gomez", reason: "no_phone" }],
+      });
+    });
+  });
+});

--- a/tests/unit/context/notifications/bulk-send.test.ts
+++ b/tests/unit/context/notifications/bulk-send.test.ts
@@ -68,11 +68,98 @@ describe("NotificationsService.bulkSend", () => {
   }
 
   function postedBody() {
-    return vi.mocked(axios.post).mock.calls[0][1] as { to: string[]; message: string };
+    return vi.mocked(axios.post).mock.calls[0][1] as {
+      to?: string[];
+      message?: string;
+      items?: { to: string; message: string }[];
+    };
   }
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  /**
+   * {nombre} personalization. When the template carries the token, the payload
+   * switches to per-recipient items with the name already interpolated — the
+   * notifications service never sees the token or knows any client's name.
+   */
+  describe("personalizing with {nombre}", () => {
+    it("posts per-recipient items with each client's name", async () => {
+      acceptWith("batch-1", 2);
+      const { service } = createService([
+        client(ID_A, "099123456", "Ana Perez"),
+        client(ID_B, "099123457", "Beto Diaz"),
+      ]);
+
+      await service.bulkSend({ clientIds: [ID_A, ID_B], message: "Hola {nombre}!" });
+
+      expect(postedBody().items).toEqual([
+        { to: "+59899123456", message: "Hola Ana Perez!" },
+        { to: "+59899123457", message: "Hola Beto Diaz!" },
+      ]);
+      expect(postedBody().to).toBeUndefined();
+      expect(postedBody().message).toBeUndefined();
+    });
+
+    it("replaces every occurrence of the token", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456", "Ana")]);
+
+      await service.bulkSend({
+        clientIds: [ID_A],
+        message: "{nombre}, tu plan {nombre} vence",
+      });
+
+      expect(postedBody().items?.[0].message).toBe("Ana, tu plan Ana vence");
+    });
+
+    it("falls back to the email when the client has no name", async () => {
+      acceptWith();
+      const noName = {
+        _id: ID_A,
+        email: "ana@mail.com",
+        userInfo: { phone: "099123456" },
+      };
+      const { service } = createService([noName as never]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: "Hola {nombre}" });
+
+      expect(postedBody().items?.[0].message).toBe("Hola ana@mail.com");
+    });
+
+    it("normalizes the template before interpolating", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456", "Ana")]);
+
+      await service.bulkSend({
+        clientIds: [ID_A],
+        message: "Hola {nombre}\r\n-Corremos el sabado",
+      });
+
+      expect(postedBody().items?.[0].message).toBe("Hola Ana\n- Corremos el sabado");
+    });
+
+    it("keeps the shared-message shape when the template has no token", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456")]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: "Hola a todos" });
+
+      expect(postedBody().items).toBeUndefined();
+      expect(postedBody().to).toEqual(["+59899123456"]);
+      expect(postedBody().message).toBe("Hola a todos");
+    });
+
+    /** A "$" in a name must never trigger replace()'s $-pattern expansion. */
+    it("keeps dollar signs in names literal", async () => {
+      acceptWith();
+      const { service } = createService([client(ID_A, "099123456", "Ana $orteo")]);
+
+      await service.bulkSend({ clientIds: [ID_A], message: "Hola {nombre}" });
+
+      expect(postedBody().items?.[0].message).toBe("Hola Ana $orteo");
+    });
   });
 
   describe("resolving the selection into recipients", () => {
@@ -240,7 +327,7 @@ describe("NotificationsService.bulkSend", () => {
 
       await service.bulkSend({ clientIds: [ID_A], message: CAMPAIGN });
 
-      expect(postedBody().message.split("\n")).toHaveLength(3);
+      expect(postedBody().message?.split("\n")).toHaveLength(3);
       expect(postedBody().message).not.toContain("\r");
     });
 

--- a/tests/unit/context/notifications/notifications.service.test.ts
+++ b/tests/unit/context/notifications/notifications.service.test.ts
@@ -23,9 +23,17 @@ describe("NotificationsService.bulkUpload", () => {
     "https://encarrera.uy/formulario",
   ].join("\n");
 
-  /** Unconfigured on purpose, so parsing is what gets tested. */
+  /**
+   * Unconfigured on purpose, so parsing is what gets tested. The client model
+   * is never touched by this path: bulkUpload reads recipients from the file,
+   * not from the database.
+   */
   function createService() {
-    return new NotificationsService({} as never, { get: () => undefined } as never);
+    return new NotificationsService(
+      {} as never,
+      { get: () => undefined } as never,
+      {} as never,
+    );
   }
 
   function upload(csv: string, originalname = "campania.csv", mimetype = "text/csv") {

--- a/tests/unit/context/notifications/test-send.test.ts
+++ b/tests/unit/context/notifications/test-send.test.ts
@@ -1,0 +1,94 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationsService } from "../../../../src/context/notifications/notifications.service";
+
+vi.mock("axios");
+
+/**
+ * testSend backs the "Probame a mí primero" button: it ships the exact body a
+ * client would receive, but to the admin's own phone, through the individual
+ * send endpoint of the notifications service. It exists so a typo is caught on
+ * one handset instead of on three hundred.
+ */
+describe("NotificationsService.testSend", () => {
+    const SERVICE_URL = "http://localhost:3000";
+    const API_KEY = "pf_test_key";
+    const SEND_URL = `${SERVICE_URL}/notifications/send`;
+
+    function createService(configured = true) {
+        const configService = {
+            get: vi.fn().mockImplementation((key: string) => {
+                if (!configured) return undefined;
+                if (key === "NOTIFICATIONS_SERVICE_URL") return SERVICE_URL;
+                if (key === "NOTIFICATIONS_SERVICE_API_KEY") return API_KEY;
+                return undefined;
+            }),
+        };
+
+        return new NotificationsService({} as never, configService as never, {} as never);
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("posts a whatsapp send with the normalized phone and message", async () => {
+        vi.mocked(axios.post).mockResolvedValue({
+            data: { jobId: "job-1", status: "queued", scheduledFor: "2026-08-08T16:00:00Z" },
+        });
+        const service = createService();
+
+        const result = await service.testSend({
+            phone: "099 123 456",
+            message: "Hola Ana\r\n-Corremos el sabado",
+        });
+
+        expect(axios.post).toHaveBeenCalledWith(
+            SEND_URL,
+            {
+                channel: "whatsapp",
+                to: "+59899123456",
+                message: "Hola Ana\n- Corremos el sabado",
+            },
+            expect.objectContaining({ headers: { "X-Api-Key": API_KEY } }),
+        );
+        expect(result).toEqual({
+            jobId: "job-1",
+            status: "queued",
+            scheduledFor: "2026-08-08T16:00:00Z",
+        });
+    });
+
+    it("rejects an unusable phone before any request leaves", async () => {
+        const service = createService();
+
+        await expect(
+            service.testSend({ phone: "12", message: "Hola" }),
+        ).rejects.toThrow(/phone/i);
+
+        expect(axios.post).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the reason the notifications service gave", async () => {
+        vi.mocked(axios.post).mockRejectedValue({
+            message: "Request failed with status code 401",
+            response: { status: 401, data: { message: "Insufficient scopes" } },
+        });
+        const service = createService();
+
+        await expect(
+            service.testSend({ phone: "099123456", message: "Hola" }),
+        ).rejects.toThrow("Insufficient scopes");
+    });
+
+    it("fails loudly when the notifications service is not configured", async () => {
+        const service = createService(false);
+
+        await expect(
+            service.testSend({ phone: "099123456", message: "Hola" }),
+        ).rejects.toThrow(/not configured/i);
+
+        expect(axios.post).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Qué

Envío masivo por WhatsApp a clientes seleccionados, sin archivo, más personalización y una prueba previa.

- **`POST /notifications/bulk-send`**: el dashboard manda los ids seleccionados; este servicio resuelve los teléfonos, normaliza a E.164 y reporta por nombre a quién no pudo alcanzar. Un teléfono inválido ya no mata la campaña entera.
- **Personalización con `{nombre}`**: si la plantilla trae el token, el payload pasa a `items[]` con el nombre ya interpolado por cliente.
- **`POST /notifications/test-send`**: manda el cuerpo de la campaña a un solo teléfono, el del admin, por el mismo camino que recorre un cliente.

## Por qué la interpolación vive acá

El notifications-service solo recibe teléfonos, nunca nombres. Este es el último punto del flujo donde el nombre existe, así que es el único lugar donde el reemplazo puede ocurrir.

`interpolateName` usa `split/join` y no `String.replace`: un nombre que contenga `$&` dispararía la expansión de patrones dólar de `replace` y corrompería el mensaje. Hay un test que lo cubre.

## Tests

60 tests en el módulo de notificaciones. Los fixtures del contrato con el notifications-service están duplicados a propósito en ambos lados: no se puede importar entre repos, así que si uno deriva, una de las dos suites se pone roja.

## Nota aparte, no incluida en este PR

`.env` está trackeado en el repo desde varios commits atrás. `.gitignore` tiene `.env*`, pero eso no aplica a archivos ya trackeados. El archivo contiene los secretos de JWT, la URI de Mongo Atlas con credenciales y la secret de reCAPTCHA. Requiere rotarlos y sacarlo del índice; queda fuera del alcance de este PR.
